### PR TITLE
Remove unused psr/log dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
     "ext-curl": "*",
     "ext-json": "*",
     "ext-mbstring": "*",
-    "guzzlehttp/guzzle": "^7",
-    "psr/log": "^1.1"
+    "guzzlehttp/guzzle": "^7"
   },
   "autoload": {
     "psr-4": { "Files\\" : "lib/" }


### PR DESCRIPTION
The psr/log dependency is outdated and doesn't appear to be used in this package.  Currently causing peer conflicts for my use case.  Let me know if I can provide anything else.

Thanks!